### PR TITLE
fix: linkify the whole Download button

### DIFF
--- a/src/components/download/selection.jsx
+++ b/src/components/download/selection.jsx
@@ -4,7 +4,7 @@ import Banner from './banner';
 
 const DownloadSelection = () => {
   const [selectedPlatform, setSelectedPlatform] = useState('generic');
-  
+
   // Function to render content based on selected platform
   const renderContent = () => {
     let contentArray = [];
@@ -18,30 +18,32 @@ const DownloadSelection = () => {
     }
 
     return contentArray.map((content, index) => (
-        <div key={index} className="p-4 my-4 mx-2 bg-site-300 text-white rounded-lg shadow-md col">
-            <h3 className="text-2xl mb-2">{content.title}</h3>
-            <p><strong>Download Size:</strong> {content.details.downloadSize}</p>
-            <p className="mt-2"><strong>Kernel:</strong> <code>{content.details.kernel}</code></p>
-            <p className="mt-2"><a href={content.details.sourceCode} target="_blank" rel="noopener noreferrer" className="text-rhino-purple underline">Source Code</a></p>
-            {content.details.login && (
-                <div className="bg-site-200 rounded-[0.65em] p-2 my-2 w-40">
-                <code>Login: {content.details.login.username} <br /> Password: {content.details.login.password} <br /></code>
-                </div>
-            )}
-            <button className="mt-4 hover:scale-105 transition-all bg-rhino-purple rounded-[0.65em] text-white text-xl px-4 py-2 shadow-md mr-2"><a href={content.details.downloadMirror} target="_blank" rel="noopener noreferrer">Download</a></button>
-            <div className="tooltip">
-              <span className="tooltiptext" id={content.title}>Copy to clipboard</span>
-              <button
-                onClick={() => {
-                  navigator.clipboard.writeText(content.details.shasum);
-                  document.getElementById(content.title).innerHTML = "Copied to clipboard!";
-                }}
-                onMouseOut={() => {
-                  document.getElementById(content.title).innerHTML = "Copy to clipboard";
-                }}
-             className="my-4 hover:scale-105 transition-all bg-site-100 p-1 rounded-[0.65em] text-white text-sm px-2 py-1 shadow-md">sha256sum</button>
-            </div>
+      <div key={index} className="p-4 my-4 mx-2 bg-site-300 text-white rounded-lg shadow-md col">
+        <h3 className="text-2xl mb-2">{content.title}</h3>
+        <p><strong>Download Size:</strong> {content.details.downloadSize}</p>
+        <p className="mt-2"><strong>Kernel:</strong> <code>{content.details.kernel}</code></p>
+        <p className="mt-2"><a className="text-rhino-purple underline" href={content.details.sourceCode} target="_blank" rel="noopener noreferrer">Source Code</a></p>
+        {content.details.login && (
+          <div className="bg-site-200 rounded-[0.65em] p-2 my-2 w-40">
+            <code>Login: {content.details.login.username} <br /> Password: {content.details.login.password} <br /></code>
+          </div>
+        )}
+        <a className="inline-block mt-4 mr-2" href={content.details.downloadMirror} target="_blank" rel="noopener noreferrer">
+          <button className="hover:scale-105 transition-all bg-rhino-purple rounded-[0.65em] text-white text-xl px-4 py-2 shadow-md">Download</button>
+        </a>
+        <div className="tooltip">
+          <span className="tooltiptext" id={content.title}>Copy to clipboard</span>
+          <button
+            onClick={() => {
+              navigator.clipboard.writeText(content.details.shasum);
+              document.getElementById(content.title).innerHTML = "Copied to clipboard!";
+            }}
+            onMouseOut={() => {
+              document.getElementById(content.title).innerHTML = "Copy to clipboard";
+            }}
+         className="my-4 hover:scale-105 transition-all bg-site-100 p-1 rounded-[0.65em] text-white text-sm px-2 py-1 shadow-md">sha256sum</button>
         </div>
+      </div>
     ));
   };
 


### PR DESCRIPTION
Before this fix, only the text on the Download button is a link, and clicking anywhere on the btn & out of the text would lead to nothing. Move the button into the `<a>` fixes this.

Move classNames of `<a>`s to the start & fix the indent by the way.

(Actually the `<button>` can be skipped without much compromise if you add `role="button"` to the `<a>`.)